### PR TITLE
Fix package signing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ for i in apple-t2-audio-config  linux-t2 gpu-switch; do # apple-ibridge-dkms-git
 done
 
 cp */*.pkg.tar.* ./
-repo-add --sign ./$repo_owner-t2.db.tar.gz ./*.pkg.tar.*
+repo-add --sign ./$repo_owner-t2.db.tar.gz ./*.pkg.tar.zst
 
 for i in *.db *.files; do
 cp --remove-destination $(readlink $i) $i


### PR DESCRIPTION
Make `repo-add` only add package files, not the signature files, which are detected with no configuration. The package files currently only end in `.pkg.tar.zst`, `pkg.tar.*` also includes `pkg.tar.zst.sig` which should not be passed to `repo-add`.

If the default compression type for `makepkg` is changed, then this would have to be updated.