### PR TITLE
Fix a shell script bug.

### DIFF
--- a/apple-ibridge-dkms-git/rm-apple-ib-tb.sh
+++ b/apple-ibridge-dkms-git/rm-apple-ib-tb.sh
@@ -1,4 +1,4 @@
-!/bin/sh
+#!/bin/sh
 if [ "${1}" == "pre" ];
 then rmmod apple_ib_tb
 elif [ "${1}" == "post" ];


### PR DESCRIPTION
"rm-apple-ib-tb.sh" is used to prevent errors of sleep,
but the script is not correct, cause it is not functional.

Here is the error log form journalctl.
``` bash
[2210]: /usr/lib/systemd/system-sleep/rm-apple-ib-tb.sh failed with exit status 1.
[2211]: Failed to execute /usr/lib/systemd/system-sleep/rm-apple-ib-tb.sh: Exec format error
```
I have test this patch, it works.
And the old release packages still contains wrong script,
which may cause other users touch bar not work after suspend.